### PR TITLE
docs(permissions): update PAT (classic) scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Since we use the GitHub API and actions to generate the data, you will need to e
 
 You will need to set a secret in the repository settings. The secret is a GitHub token that has admin read access to the organization. You can create a token by going to `Settings` -> `Developer settings` -> `Personal access tokens` and creating a new token with the following scopes.
 
+- public_repo
 - read:org
-- read:repo
 - read:project
 
 > [!NOTE]
@@ -76,8 +76,8 @@ cp .env.example .env
 
 The `GRAPHQL_TOKEN` token requires the following scopes:
 
+- public_repo
 - read:org
-- read:repo
 - read:project
 
 > [!NOTE]


### PR DESCRIPTION
closes #167 

also re-ordered per the new PAT screen so you don't hunt up and down

perhaps regardless of Scoped or Classic PAT, future work should clarify which is expected